### PR TITLE
修复无痕访问时主页报错

### DIFF
--- a/Access_Core.php
+++ b/Access_Core.php
@@ -345,7 +345,7 @@ class Access_Core
             $entrypoint = Typecho_Cookie::get('__typecho_access_entrypoint');
         }
         if (parse_url($entrypoint, PHP_URL_HOST) == parse_url(Helper::options()->siteUrl, PHP_URL_HOST)) {
-            $entrypoint = null;
+            $entrypoint = '';
         }
         if ($entrypoint != null) {
             Typecho_Cookie::set('__typecho_access_entrypoint', $entrypoint);


### PR DESCRIPTION
Deprecated: parse_url(): Passing null to parameter Anankke#1 ($url) of type string is deprecated in /usr/plugins/Access/Access_Core.php on line 402